### PR TITLE
fix objects for twitch event

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -374,7 +374,7 @@ function handleTwitchEvent(data) {
 
       if (supressGiftBombSubEvents && eventInfo?.type === "GiftBomb") {
         giftSubIds.push(
-          ...(eventInfo?.giftSubs?.map((sub) => sub?.recipientUserId) || [])
+          ...(eventData?.recipients?.map((sub) => sub?.id) || [])
         );
       }
 


### PR DESCRIPTION
Giftbomb events changed and I hadn't noticed. This update fixes the code for giftsub suppression based on the new objects